### PR TITLE
Fix not fetching data in time bug

### DIFF
--- a/src/components/SearchBarAndButton.tsx
+++ b/src/components/SearchBarAndButton.tsx
@@ -7,7 +7,7 @@ import { withNavigation } from 'react-navigation';
 /**
  * 
  */
-function SearchBar({ searchTerm, onTermChange, onCitySubmit, navigation, cityName, cityPopulation }: any) {
+export default function SearchBar({ searchTerm, onTermChange, onCitySubmit }: any) {
     return ( // navigation.navigate("Results", {name: cityName, population: cityPopulation})
         <View>
             <TextInput 
@@ -15,11 +15,9 @@ function SearchBar({ searchTerm, onTermChange, onCitySubmit, navigation, cityNam
                 placeholder="Enter a city" 
                 value={searchTerm}
                 onChangeText={onTermChange}
-                //onEndEditing={onCitySubmit}
             />
             <TouchableOpacity
-                onPress={onCitySubmit} 
-                onPressIn={() => navigation.navigate("Results", {name: cityName, population: cityPopulation})}
+                onPress={onCitySubmit}
                 style={styles.touchableOpacityDimensions}
             >
                 <View style={styles.button}>
@@ -28,32 +26,32 @@ function SearchBar({ searchTerm, onTermChange, onCitySubmit, navigation, cityNam
             </TouchableOpacity>
         </View>
     ); 
-  }
+}
   
-  const styles = StyleSheet.create({
-      background: {
-          backgroundColor: "#F0EEEE",
-          fontSize: 20,
-          height: 50,
-          borderRadius: 5,
-          marginBottom: 10,
-          marginLeft: 30,
-          marginRight: 30,
-          textAlign: 'center',
-          borderColor: "black",
-          borderWidth: 1
-      },
-      // Touchableopacity takes up the whole screen horizontally, so cutting of size from
-      // its' left and right means the user has to press directly on the search button for it 
-      // to do anything (previously, they could press the white space around it).
-      touchableOpacityDimensions: {  
-          marginLeft: 150,
-          marginRight: 150,
+const styles = StyleSheet.create({
+    background: {
+        backgroundColor: "#F0EEEE",
+        fontSize: 20,
+        height: 50,
+        borderRadius: 5,
+        marginBottom: 10,
+        marginLeft: 30,
+        marginRight: 30,
+        textAlign: 'center',
+        borderColor: "black",
+        borderWidth: 1
     },
-      button: {
-        alignItems: 'center',
-        justifyContent: 'center',
-      },
-  });
+    /* Touchableopacity takes up the whole screen horizontally, so cutting of size from
+    its' left and right means the user has to press directly on the search button for it 
+    to do anything (previously, they could press the white space around it). */
+    touchableOpacityDimensions: {  
+        marginLeft: 150,
+        marginRight: 150,
+    },
+    button: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    },
+});
 
-  export default withNavigation(SearchBar);
+  // export default withNavigation(SearchBar);

--- a/src/hooks/useCity.tsx
+++ b/src/hooks/useCity.tsx
@@ -1,56 +1,52 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import GeoNames from '../api/GeoNames';
 
+/**
+ * A hook that is used to fetch the name of a city a user searches for as well as its' population size.
+ * 
+ * @returns the function searchApi, an object that is either null or includes the name of the
+ * city that the user searched for and its' population size, and an error message that is either
+ * null or a string if the get request returned an empty geonames array (i.e. the city doesn't exist).
+ */
 export default function useCity() {
     const [result, setResult] = useState([]);
     const [errorMessage, setErrorMessage] = useState("");
 
-    
-    /* 
-    TODOs: !!!!!!!!!!!
-
-    Should maybe include the order by parameter even in this stage. Presumably,
-    if there are two cities called London (which there are), the user probably meant
-    the one with the largest population.
-
-    Should chech that the name key EQUALS (not includes) the search term. 
-    Be careful of whitespace? E.g. will "Stockholm" work but and "Stockholm " fail?
-
-    Might want to remove the cities parameter and have custom logic, e.g. if one searches for 
-    city X, have a for loop that checks each element until it finds one where the name key
-    equals X and the fclName key points to a value that includes the substring city.
-    It should then return the first one it finds, else throw an error message saying the
-    city doesn't exist. 
-    */
-    const searchApi: any = async (enteredCity: any) => {
+    const searchApi: any = async (enteredTerm: any) => {
         try {
             const response = await GeoNames.get("/searchJSON", {
                 params: {
                     username: "weknowit",
-                    name_equals: enteredCity, // searchTerm,
-                    cities: "cities1000"
+                    name_equals: enteredTerm,
+                    /* Since cities are defined as inhabited places with a greater size and population than
+                    towns or villages, I'm chosing to filter the results to only include cities with a population
+                    size greater than 500. The reason for this is that certain names in the GeoNames api, e.g.
+                    "Hello", are (1) not a city (for instance, it might be a mountain or lake), or (2) includes 
+                    the string "city, village" in the fclName attribute, but have a population of 0. I want to 
+                    filter out these places here, as it means we don't have to filter these places using custom logic. */
+                    cities: "cities500", 
                 }
             });
-    
-            /*
-            When we enter the name of a city, e.g. Stockholm, it appears as the first 
-            element of the geonames array. Therefore, we set results to only include
-            that object. 
-    
-            We also have to check that the fclName attribute contains the substring "city", as
-            we are only interested in citites, not mountains for instance. If it doesn't, we 
-            don't add the object to result and we display an error message. 
-            */
-            if (response.data.geonames[0].fclName.includes("city")) {
-                setResult(response.data.geonames[0]);
-                setErrorMessage("");
+
+            /* When we enter the name of a city, e.g. Stockholm, it appears as the first element of the geonames array. 
+            Occasionally, more than one city has the same name (e.g. "London"). In this case, we assume the user meant
+            the city of London in England, which is the first element in the geonames array.Therefore, we set results 
+            to be the first element of the geonames array. We also check that the name key of the first element contains
+            a value equal to the entered term. Otherwise, a search for "Sa" returned the city Sia. Not sure why this is,
+            since I added the name_equals parameter. But checking this manually works. */
+            if (response.data.geonames.length >= 1 && response.data.geonames[0].name === enteredTerm) {
+                let cityTheUserSearchedFor = response.data.geonames[0];
+                setResult(cityTheUserSearchedFor);
             } else {
-                setErrorMessage("Oops! Looks like that city doesn't exist :(")
+                setErrorMessage("City doesn't exist, please try again")
             }
+             
         } catch (err) {
-            setErrorMessage("Oops! Looks like that city doesn't exist :(")
+            setErrorMessage("Oops! Something went wrong...")
         }
     };
 
-    return [searchApi, result, errorMessage]; // needed in SearchByCityScreen
+    /* SearchByCityScreen uses this function, the result from calling the function and the error message.
+    As such all three constant need to be returned to it. */
+    return [searchApi, result, errorMessage]; 
 }

--- a/src/hooks/useCity.tsx
+++ b/src/hooks/useCity.tsx
@@ -5,6 +5,23 @@ export default function useCity() {
     const [result, setResult] = useState([]);
     const [errorMessage, setErrorMessage] = useState("");
 
+    
+    /* 
+    TODOs: !!!!!!!!!!!
+
+    Should maybe include the order by parameter even in this stage. Presumably,
+    if there are two cities called London (which there are), the user probably meant
+    the one with the largest population.
+
+    Should chech that the name key EQUALS (not includes) the search term. 
+    Be careful of whitespace? E.g. will "Stockholm" work but and "Stockholm " fail?
+
+    Might want to remove the cities parameter and have custom logic, e.g. if one searches for 
+    city X, have a for loop that checks each element until it finds one where the name key
+    equals X and the fclName key points to a value that includes the substring city.
+    It should then return the first one it finds, else throw an error message saying the
+    city doesn't exist. 
+    */
     const searchApi: any = async (enteredCity: any) => {
         try {
             const response = await GeoNames.get("/searchJSON", {

--- a/src/hooks/useCity.tsx
+++ b/src/hooks/useCity.tsx
@@ -11,6 +11,7 @@ import GeoNames from '../api/GeoNames';
 export default function useCity() {
     const [result, setResult] = useState([]);
     const [errorMessage, setErrorMessage] = useState("");
+    const [dataIsFetched, setDataIsFetched] = useState(false);
 
     const searchApi: any = async (enteredTerm: any) => {
         try {
@@ -37,8 +38,11 @@ export default function useCity() {
             if (response.data.geonames.length >= 1 && response.data.geonames[0].name === enteredTerm) {
                 let cityTheUserSearchedFor = response.data.geonames[0];
                 setResult(cityTheUserSearchedFor);
+                setErrorMessage(""); // TODO: Remove, redudant once ResultsScreen takes user back to home screen but looks nicer now.
+                setDataIsFetched(true);
             } else {
-                setErrorMessage("City doesn't exist, please try again")
+                setErrorMessage("City doesn't exist, please try again");
+                setDataIsFetched(false);
             }
              
         } catch (err) {
@@ -48,5 +52,5 @@ export default function useCity() {
 
     /* SearchByCityScreen uses this function, the result from calling the function and the error message.
     As such all three constant need to be returned to it. */
-    return [searchApi, result, errorMessage]; 
+    return [searchApi, result, errorMessage, dataIsFetched]; 
 }

--- a/src/screens/ResultsScreen.tsx
+++ b/src/screens/ResultsScreen.tsx
@@ -7,7 +7,7 @@ import GeoNames from '../api/GeoNames';
  * 
  * @returns A results screen.
  */
-export default function ResultsScreen( {navigation}: any) {
+export default function ResultsScreen({navigation}: any) {
     const nameOfCity = navigation.getParam("name");
     const poplationSize = navigation.getParam("population");
 

--- a/src/screens/SearchByCityScreen.tsx
+++ b/src/screens/SearchByCityScreen.tsx
@@ -8,25 +8,20 @@ import useCity from '../hooks/useCity';
  * 
  * @returns A search by city screen.
  */
-export default function SearchByCityScreen() {
+export default function SearchByCityScreen({navigation}: any) {
     const [searchTerm, setSearchTerm] = useState("");
-    const [searchApi, result, errorMessage] = useCity();
+    const [searchApi, result, errorMessage, dataIsFetched] = useCity();
     
-    console.log(result); // TODO: remove
-
     return(
         <View>
             <Text style={styles.title}>SEARCH BY CITY</Text>
             <SearchBar 
                 searchTerm={searchTerm} 
                 onTermChange={setSearchTerm} 
-                onCitySubmit={() => searchApi(searchTerm)}
-                cityName={result.name}
-                cityPopulation={result.population}
+                onCitySubmit={() => (searchApi(searchTerm))}
             />
+            {dataIsFetched ? navigation.navigate("Results", {name: result.name, population: result.population}) : null}
             {errorMessage ? <Text style={styles.errorMessage}>{errorMessage}</Text> : null}
-            <Text>Name of city: {result.name}</Text>
-            <Text>Population: {result.population}</Text>
         </View>
     )
 }

--- a/src/screens/SearchByCityScreen.tsx
+++ b/src/screens/SearchByCityScreen.tsx
@@ -12,7 +12,7 @@ export default function SearchByCityScreen() {
     const [searchTerm, setSearchTerm] = useState("");
     const [searchApi, result, errorMessage] = useCity();
     
-    console.log(result);
+    console.log(result); // TODO: remove
 
     return(
         <View>


### PR DESCRIPTION
When a user enters an existing city and presses the search button the data is fetched, and when it has been fetched the user is taken to the results screen where the name of the city and its' population size is shown. If the user enters a city that doesn't exist, an error message is shown on the screen. 

Currently not showing an AcitivityIndicator when data is loading. 

Bugs: 
1. There's currently an unhandled warning message. When expo is started, and one does the above, one gets the warning "Cannot update during an existing state transition". 
2. For some reason I sometimes get the "City doesn't exist, please try again" message when I search for Rome, but not for other cities. Maybe it's because I've searched for Rome more than any other city, so that there is something going on on the Geonames-side?